### PR TITLE
Added a nix flake file

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1680498889,
+        "narHash": "sha256-4nGFBm+oILOO6DPoKTPxVlfkZSxCOY4W25zSRHESK48=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "799d153e4f316143a9db0eb869ecf44d8d4c0356",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-22.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,35 @@
+{
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-22.11";
+
+  outputs = { self, nixpkgs }:
+  let
+    pkgs = nixpkgs.legacyPackages.x86_64-linux;
+
+  in with pkgs;
+  let
+    dependencies = [ ripgrep fzf bat ];
+  in {
+    devShell.x86_64-linux = mkShell { 
+      buildInputs = dependencies;
+    };
+    defaultPackage.x86_64-linux = 
+    stdenv.mkDerivation {
+       name = "fzf-search";
+       src = self;
+       buildInputs = [makeWrapper ];
+       installPhase = "
+         mkdir -p $out/bin; 
+         install -t $out/bin fzf-search;
+         install -t $out/bin fzf-file;
+         install -t $out/bin help.1"; #TODO it doesn't belong there
+       postFixup =
+       let
+         dependency_path = pkgs.lib.makeBinPath dependencies;
+       in
+       ''
+         wrapProgram "$out/bin/fzf-search" --prefix PATH : "${dependency_path}"
+       '';
+    };
+  };
+
+}

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
     devShell.x86_64-linux = mkShell { 
       buildInputs = dependencies;
     };
-    defaultPackage.x86_64-linux = 
+    packages.x86_64-linux.fzf-search = 
     stdenv.mkDerivation {
        name = "fzf-search";
        src = self;
@@ -28,8 +28,24 @@
        in
        ''
          wrapProgram "$out/bin/fzf-search" --prefix PATH : "${dependency_path}"
+         wrapProgram "$out/bin/fzf-file" --prefix PATH : "${dependency_path}"
        '';
     };
+
+    # nix run <loc>#fzf-search
+    apps.x86_64-linux.fzf-search = {
+    type = "app";
+    program = "${self.packages.x86_64-linux.fzf-search}/bin/fzf-search";
+    };
+
+    # nix run <loc>#fzf-file
+    apps.x86_64-linux.fzf-file = {
+    type = "app";
+    program = "${self.packages.x86_64-linux.fzf-search}/bin/fzf-file";
+    };
+
+    # Default nix run
+    apps.x86_64-linux.default = self.apps.x86_64-linux.fzf-search;
   };
 
 }


### PR DESCRIPTION
This should make the package runnable with `nix run github:suvayu/fzf_search`

- [x] add `apps` to allow `fzf-search` and `fzf-file` to be called with `nix run github:suvayu/fzf_search#fzf-search` and  `nix run github:suvayu/fzf_search#fzf-file`